### PR TITLE
Fix docker builder stage of whatsapp server

### DIFF
--- a/nestjs_server/Dockerfile
+++ b/nestjs_server/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 FROM installer AS builder
 WORKDIR /app/src/app
 
-RUN npm run build
+RUN npm install -g @nestjs/cli && npm run build
 
 FROM builder AS production
 WORKDIR /app/src/app


### PR DESCRIPTION
## :wrench: Bug description

On the builder stage, occours an error trying to run the "nest" command, saying that isn't found.

## :mag_right: Root cause

The nest CLI wasn't installed in the docker container

## :bulb: Solution

I'm forcing the installation of the nest CLI
